### PR TITLE
a workaround for not adding first and last month in xml

### DIFF
--- a/library/src/main/java/com/andexert/calendarlistview/library/SimpleMonthAdapter.java
+++ b/library/src/main/java/com/andexert/calendarlistview/library/SimpleMonthAdapter.java
@@ -50,7 +50,7 @@ public class SimpleMonthAdapter extends RecyclerView.Adapter<SimpleMonthAdapter.
         this.typedArray = typedArray;
         calendar = Calendar.getInstance();
         firstMonth = typedArray.getInt(R.styleable.DayPickerView_firstMonth, calendar.get(Calendar.MONTH));
-        lastMonth = typedArray.getInt(R.styleable.DayPickerView_lastMonth, (calendar.get(Calendar.MONTH) - 1) % MONTHS_IN_YEAR);
+        lastMonth = typedArray.getInt(R.styleable.DayPickerView_lastMonth, MONTHS_IN_YEAR - 1);
         selectedDays = new SelectedDays<>();
 		mContext = context;
 		mController = datePickerController;

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -9,6 +9,8 @@
         android:id="@+id/pickerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        calendar:firstMonth="january"
+        calendar:lastMonth="december"
         calendar:drawRoundRect="true"/>
 
 </RelativeLayout>


### PR DESCRIPTION
Setting default last month like this 
```
lastMonth = typedArray.getInt(R.styleable.DayPickerView_lastMonth, (calendar.get(Calendar.MONTH) - 1) % MONTHS_IN_YEAR);
```
usually ends up with empty listView, as the getCount will return 0. So I setting it to last month in year may be a good work around.