### PR TITLE
New attribute "singleSelectionOnly" that allows selection of only 1 day

### DIFF
--- a/library/src/main/java/com/andexert/calendarlistview/library/SimpleMonthAdapter.java
+++ b/library/src/main/java/com/andexert/calendarlistview/library/SimpleMonthAdapter.java
@@ -145,22 +145,22 @@ public class SimpleMonthAdapter extends RecyclerView.Adapter<SimpleMonthAdapter.
 
 	protected void init() {
         if (typedArray.getBoolean(R.styleable.DayPickerView_currentDaySelected, false))
-            onDayTapped(new CalendarDay(System.currentTimeMillis()));
+            onDayTapped(new CalendarDay(System.currentTimeMillis()), false);
 	}
 
 	public void onDayClick(SimpleMonthView simpleMonthView, CalendarDay calendarDay) {
 		if (calendarDay != null) {
-			onDayTapped(calendarDay);
+			onDayTapped(calendarDay, simpleMonthView.isSingleSelectionOnly());
         }
 	}
 
-	protected void onDayTapped(CalendarDay calendarDay) {
+	protected void onDayTapped(CalendarDay calendarDay, boolean selection) {
 		mController.onDayOfMonthSelected(calendarDay.year, calendarDay.month, calendarDay.day);
-		setSelectedDay(calendarDay);
+		setSelectedDay(calendarDay, selection);
 	}
 
-	public void setSelectedDay(CalendarDay calendarDay) {
-        if (selectedDays.getFirst() != null && selectedDays.getLast() == null)
+	public void setSelectedDay(CalendarDay calendarDay, boolean selection) {
+        if (selectedDays.getFirst() != null && selectedDays.getLast() == null && !selection)
         {
             selectedDays.setLast(calendarDay);
 

--- a/library/src/main/java/com/andexert/calendarlistview/library/SimpleMonthView.java
+++ b/library/src/main/java/com/andexert/calendarlistview/library/SimpleMonthView.java
@@ -103,6 +103,7 @@ class SimpleMonthView extends View
     private int mDayOfWeekStart = 0;
     protected int mMonth;
     protected Boolean mDrawRect;
+    protected Boolean mSingleSelection;
     protected int mRowHeight = DEFAULT_HEIGHT;
     protected int mWidth;
     protected int mYear;
@@ -138,6 +139,8 @@ class SimpleMonthView extends View
         mMonthTitleBGColor = typedArray.getColor(R.styleable.DayPickerView_colorSelectedDayText, resources.getColor(R.color.selected_day_text));
 
         mDrawRect = typedArray.getBoolean(R.styleable.DayPickerView_drawRoundRect, false);
+	
+	mSingleSelection = typedArray.getBoolean(R.styleable.DayPickerView_singleSelectionOnly, false);
 
         mStringBuilder = new StringBuilder(50);
 
@@ -437,6 +440,10 @@ class SimpleMonthView extends View
 
         mNumRows = calculateNumRows();
 	}
+	
+	public boolean isSingleSelectionOnly() {
+            return mSingleSelection;
+        }
 
 	public void setOnDayClickListener(OnDayClickListener onDayClickListener) {
 		mOnDayClickListener = onDayClickListener;

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
         <attr name="enablePreviousDay" format="boolean" />
         <attr name="currentDaySelected" format="boolean" />
         <attr name="drawRoundRect" format="boolean" />
+        <attr name="singleSelectionOnly" format="boolean" />
         <attr name="firstMonth" format="enum">
             <enum name="january" value="0" />
             <enum name="february" value="1" />


### PR DESCRIPTION
With a new attribute app:singleSelectionOnly="true" user can select only one day, so with already selected day it will deselect first and then select a new day instead of calling range of dates.
